### PR TITLE
Send the revision too along with the Treeherder URL when a try push is done

### DIFF
--- a/libmozevent/mercurial.py
+++ b/libmozevent/mercurial.py
@@ -342,4 +342,8 @@ class MercurialWorker(object):
                 {"message": str(e), "duration": time.time() - start},
             )
 
-        return ("success", build, {"treeherder_url": uri, "revision": tip.node.decode("utf-8")})
+        return (
+            "success",
+            build,
+            {"treeherder_url": uri, "revision": tip.node.decode("utf-8")},
+        )

--- a/libmozevent/mercurial.py
+++ b/libmozevent/mercurial.py
@@ -342,4 +342,4 @@ class MercurialWorker(object):
                 {"message": str(e), "duration": time.time() - start},
             )
 
-        return ("success", build, {"treeherder_url": uri})
+        return ("success", build, {"treeherder_url": uri, "revision": tip.node.decode("utf-8")})

--- a/tests/test_mercurial.py
+++ b/tests/test_mercurial.py
@@ -79,6 +79,7 @@ async def test_push_to_try(PhabricatorMock, mock_mc):
     ] == "https://treeherder.mozilla.org/#/jobs?repo=try&revision={}".format(
         tip.node.decode("utf-8")
     )
+    assert details["revision"] == tip.node.decode("utf-8")
     task.cancel()
 
     # The target should have content now
@@ -191,6 +192,7 @@ async def test_push_to_try_existing_rev(PhabricatorMock, mock_mc):
     ] == "https://treeherder.mozilla.org/#/jobs?repo=try&revision={}".format(
         tip.node.decode("utf-8")
     )
+    assert details["revision"] == tip.node.decode("utf-8")
     task.cancel()
 
     # The target should have content now
@@ -300,6 +302,7 @@ async def test_treeherder_link(PhabricatorMock, mock_mc):
     ] == "https://treeherder.mozilla.org/#/jobs?repo=try&revision={}".format(
         tip.node.decode("utf-8")
     )
+    assert details["revision"] == tip.node.decode("utf-8")
     task.cancel()
 
     # Tip should be updated
@@ -468,6 +471,7 @@ async def test_push_to_try_nss(PhabricatorMock, mock_nss):
     ] == "https://treeherder.mozilla.org/#/jobs?repo=try&revision={}".format(
         tip.node.decode("utf-8")
     )
+    assert details["revision"] == tip.node.decode("utf-8")
     task.cancel()
 
     # The target should have content now
@@ -568,3 +572,4 @@ async def test_crash_utf8_author(PhabricatorMock, mock_mc):
     ] == "https://treeherder.mozilla.org/#/jobs?repo=try&revision={}".format(
         mock_mc.repo.tip().node.decode("utf-8")
     )
+    assert details["revision"] == mock_mc.repo.tip().node.decode("utf-8")


### PR DESCRIPTION
This is needed for https://github.com/mozilla/code-review/pull/264.