### PR TITLE
monitoring: Use Taskcluster instance url in emails

### DIFF
--- a/libmozevent/monitoring.py
+++ b/libmozevent/monitoring.py
@@ -15,7 +15,7 @@ GROUP_MD = """
 {:.2f}% of all tasks ({}/{})
 
 """
-TASK_MD = "* [{0}](https://tools.taskcluster.net/task-inspector/#{0})"
+TASK_MD = "* [{task_id}]({base_url}/tasks/{task_id})"
 TASKCLUSTER_NAMESPACE = "project.releng.services.tasks.{task_id}"
 
 
@@ -43,6 +43,7 @@ class Monitoring(object):
         self.notify = taskcluster_config.get_service("notify")
         self.queue = taskcluster_config.get_service("queue")
         self.index = taskcluster_config.get_service("index")
+        self.taskcluster_base_url = taskcluster_config.default_url
 
     def register(self, bus):
         self.bus = bus
@@ -195,7 +196,12 @@ class Monitoring(object):
                 content += GROUP_MD.format(
                     status, 100.0 * nb_tasks / total, nb_tasks, total
                 )
-                content += "\n".join([TASK_MD.format(task) for task in tasks])
+                content += "\n".join(
+                    [
+                        TASK_MD.format(task_id=task, base_url=self.taskcluster_base_url)
+                        for task in tasks
+                    ]
+                )
             contents.append(content)
 
         if len(contents):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -368,7 +368,9 @@ def mock_taskcluster():
     Mock Tasklcuster authentication
     """
     tc = TaskclusterConfig("http://taskcluster.test")
-    tc.auth()
-    tc.options["maxRetries"] = 1
 
+    # Force options to avoid auto proxy detection
+    tc.auth("client", "token")
+    tc.default_url = "http://taskcluster.test"
+    tc.options["maxRetries"] = 1
     return tc

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -76,8 +76,8 @@ async def test_monitoring(QueueMock, NotifyMock, mock_taskcluster):
 
 66.67% of all tasks (2/3)
 
-* [Task1-completed](https://tools.taskcluster.net/task-inspector/#Task1-completed)
-* [Task2-completed](https://tools.taskcluster.net/task-inspector/#Task2-completed)
+* [Task1-completed](http://taskcluster.test/tasks/Task1-completed)
+* [Task2-completed](http://taskcluster.test/tasks/Task2-completed)
 
 ## exception
 
@@ -89,7 +89,7 @@ async def test_monitoring(QueueMock, NotifyMock, mock_taskcluster):
 
 33.33% of all tasks (1/3)
 
-* [Task-failed](https://tools.taskcluster.net/task-inspector/#Task-failed)
+* [Task-failed](http://taskcluster.test/tasks/Task-failed)
 
 # Hook2 tasks for the last period
 
@@ -104,7 +104,7 @@ async def test_monitoring(QueueMock, NotifyMock, mock_taskcluster):
 
 100.00% of all tasks (1/1)
 
-* [Task-exception](https://tools.taskcluster.net/task-inspector/#Task-exception)
+* [Task-exception](http://taskcluster.test/tasks/Task-exception)
 
 ## failed
 
@@ -184,7 +184,7 @@ async def test_monitoring_whiteline_between_failed_and_hook(
 
 100.00% of all tasks (1/1)
 
-* [Task-failed](https://tools.taskcluster.net/task-inspector/#Task-failed)
+* [Task-failed](http://taskcluster.test/tasks/Task-failed)
 
 # Hook2 tasks for the last period
 
@@ -205,7 +205,7 @@ async def test_monitoring_whiteline_between_failed_and_hook(
 
 100.00% of all tasks (1/1)
 
-* [Task-failed](https://tools.taskcluster.net/task-inspector/#Task-failed)"""
+* [Task-failed](http://taskcluster.test/tasks/Task-failed)"""
 
     monitoring.send_report()
     assert NotifyMock.email_obj["address"] == "pinco@pallino"


### PR DESCRIPTION
fixes #12 