### PR TITLE
Auto-delete queues when the last consumer using them unsubscribes

### DIFF
--- a/libmozevent/pulse.py
+++ b/libmozevent/pulse.py
@@ -64,14 +64,17 @@ async def create_pulse_listener(
         #   pulse but something we started doing in release services
         queue = f"queue/{user}/exchange/{exchange_name}"
 
-        await channel.queue_declare(queue_name=queue, durable=True)
+        await channel.queue_declare(queue_name=queue, durable=True, auto_delete=True)
 
         # in case we are going to listen to an exchange that is specific for this
         # user, we need to ensure that exchange exists before first message is
         # sent (this is what creates exchange)
         if exchange.startswith(f"exchange/{user}/"):
             await channel.exchange_declare(
-                exchange_name=exchange, type_name="topic", durable=True
+                exchange_name=exchange,
+                type_name="topic",
+                durable=True,
+                auto_delete=True,
             )
 
         for topic in topics:


### PR DESCRIPTION
Fixes #20

I'm not 100% sure, but I think we should do this.
The disadvantage is that when we e.g. pause code-review or code-coverage the queue will be killed and so we will miss some events;
The big advantage is that we will not cause queues to overgrow (the queues we are using are especially prone to overgrowing, even a few minutes of pause could mean a huge queue).