### PR TITLE
Require at least aioamqp 0.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aioamqp
+aioamqp>=0.13.0
 aioredis
 libmozdata
 Logbook


### PR DESCRIPTION
@La0 could you test this on your machine too?

If I don't do this, on my machine pulse fails with `TypeError: cannot use a bytes pattern on a string-like object`.