### PR TITLE
Add a module to store data in a temporary fashion

### DIFF
--- a/libmozevent/bus.py
+++ b/libmozevent/bus.py
@@ -8,26 +8,13 @@ import pickle
 from queue import Empty
 from typing import Callable
 
-import aioredis
 import structlog
+
+from libmozevent.utils import AsyncRedis
 
 logger = structlog.get_logger(__name__)
 
 RedisQueue = collections.namedtuple("RedisQueue", "name")
-
-
-class AsyncRedis(object):
-    """
-    Async context manager to create a redis connection
-    """
-
-    async def __aenter__(self):
-        self.conn = await aioredis.create_redis(os.environ["REDIS_URL"])
-        return self.conn
-
-    async def __aexit__(self, exc_type, exc, tb):
-        self.conn.close()
-        await self.conn.wait_closed()
 
 
 class MessageBus(object):

--- a/libmozevent/storage.py
+++ b/libmozevent/storage.py
@@ -32,7 +32,7 @@ class EphemeralStorage:
                     self.name, min=int(time.time()), max=math.inf
                 )
                 for key in keys:
-                    key = key.decode("ascii")
+                    key = key.decode("utf-8")
                     self.cache[key] = pickle.loads(
                         await redis.get(self.name + ":" + key)
                     )

--- a/libmozevent/storage.py
+++ b/libmozevent/storage.py
@@ -47,6 +47,7 @@ class EphemeralStorage:
 
         if self.redis_enabled:
             async with AsyncRedis() as redis:
+                await redis.expire(self.name, self.expiration)
                 await redis.set(
                     self.name + ":" + key, pickle.dumps(value), expire=self.expiration
                 )

--- a/libmozevent/storage.py
+++ b/libmozevent/storage.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+import math
+import os
+import pickle
+import time
+
+import structlog
+
+from libmozevent.utils import AsyncRedis
+
+logger = structlog.get_logger(__name__)
+
+
+class EphemeralStorage:
+    @classmethod
+    async def create(cls, name, expiration):
+        self = EphemeralStorage()
+        self.name = name
+        self.expiration = expiration
+        self.cache = {}
+        self.redis_enabled = "REDIS_URL" in os.environ
+        logger.info("Redis support", enabled=self.redis_enabled and "yes" or "no")
+
+        if self.redis_enabled:
+            async with AsyncRedis() as redis:
+                # Remove all expired keys from our sorted set.
+                await redis.zremrangebyscore(
+                    self.name, min=-math.inf, max=int(time.time())
+                )
+                # Load all live keys from our sorted set.
+                keys = await redis.zrangebyscore(
+                    self.name, min=int(time.time()), max=math.inf
+                )
+                for key in keys:
+                    key = key.decode("ascii")
+                    self.cache[key] = pickle.loads(
+                        await redis.get(self.name + ":" + key)
+                    )
+
+        return self
+
+    def get(self, key):
+        return self.cache[key]
+
+    async def set(self, key, value):
+        self.cache[key] = value
+
+        if self.redis_enabled:
+            async with AsyncRedis() as redis:
+                await redis.set(
+                    self.name + ":" + key, pickle.dumps(value), expire=self.expiration
+                )
+                await redis.zadd(self.name, int(time.time()) + self.expiration, key)
+
+    async def rem(self, key):
+        del self.cache[key]
+
+        if self.redis_enabled:
+            async with AsyncRedis() as redis:
+                await redis.zrem(self.name, key)

--- a/libmozevent/utils.py
+++ b/libmozevent/utils.py
@@ -7,6 +7,7 @@ import fcntl
 import os
 import time
 
+import aioredis
 import hglib
 import structlog
 
@@ -152,3 +153,17 @@ def robust_checkout(repo_url, repo_dir, branch=b"tip"):
         branch=branch,
     )
     hg_run(cmd)
+
+
+class AsyncRedis(object):
+    """
+    Async context manager to create a redis connection
+    """
+
+    async def __aenter__(self):
+        self.conn = await aioredis.create_redis(os.environ["REDIS_URL"])
+        return self.conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.conn.close()
+        await self.conn.wait_closed()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+import asyncio
+import os
+
+import pytest
+
+from libmozevent.storage import EphemeralStorage
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_storage():
+    obj1 = {"an": "object"}
+    obj2 = {"another": "object"}
+
+    storage = await EphemeralStorage.create("my_first_set", 60)
+
+    await storage.set("my_key1", obj1)
+    await storage.set("my_key2", obj2)
+
+    got_obj1 = storage.get("my_key1")
+    assert got_obj1 == obj1
+
+    got_obj2 = storage.get("my_key2")
+    assert got_obj2 == obj2
+
+    await storage.rem("my_key2")
+
+    with pytest.raises(KeyError):
+        storage.get("my_key2")
+
+    got_obj1 = storage.get("my_key1")
+    assert got_obj1 == obj1
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_storage_expiration():
+    """
+    Test a key which expires.
+    """
+    obj = {"an": "object"}
+
+    storage = await EphemeralStorage.create("my_second_set", 1)
+
+    await storage.set("my_key", obj)
+
+    got_obj = storage.get("my_key")
+    assert got_obj == obj
+
+    await asyncio.sleep(1)
+
+    storage = await EphemeralStorage.create("my_second_set", 1)
+
+    with pytest.raises(KeyError):
+        storage.get("my_key")
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_storage_no_expiration():
+    """
+    Test a key which does not expire.
+    """
+    # This test only works when Redis is available.
+    if "REDIS_URL" not in os.environ:
+        return
+
+    obj = {"an": "object"}
+
+    storage = await EphemeralStorage.create("my_third_set", 60)
+
+    await storage.set("my_key", obj)
+
+    got_obj = storage.get("my_key")
+    assert got_obj == obj
+
+    await asyncio.sleep(1)
+
+    storage = await EphemeralStorage.create("my_third_set", 60)
+
+    assert storage.get("my_key") == obj


### PR DESCRIPTION
When Redis is not available, the data is simply stored in a dict (so it is lost on restart). When Redis is available, it is stored there.

When an object of the class is created, the whole data is loaded in memory for performance reasons (we need to access it very quickly), so this class is only useful for small data (e.g. our needs for tracking bugbug stuff or for monitoring tasks). I've called it EphemeralStorage and made the expiration a compulsory argument to make it clear that it can't be used as a database.

The data is stored this way:
- Each key/value is stored as a Redis string with a given expiration;
- Each key is added to a Sorted Set, with the expiration time being the score in the set (this way we can easily and quickly remove expired keys and retrieve non-expired keys from the set).