### PR TITLE
Remove PhabricatorPatch tuple as it is not used (and already defined in libmozdata)

### DIFF
--- a/libmozevent/phabricator.py
+++ b/libmozevent/phabricator.py
@@ -8,10 +8,6 @@ from libmozdata.phabricator import PhabricatorAPI
 
 logger = structlog.get_logger(__name__)
 
-PhabricatorPatch = collections.namedtuple(
-    "Diff", "id, phid, patch, base_revision, commits"
-)
-
 
 class PhabricatorBuildState(enum.Enum):
     Queued = 1


### PR DESCRIPTION
I couldn't find any usage of it in this file or in code-review.