### PR TITLE
List aiohttp in the requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aioamqp>=0.13.0
+aiohttp
 aioredis
 libmozdata
 Logbook


### PR DESCRIPTION
Don't rely on it to be indirectly installed via the Taskcluster dependency