### PR TITLE
phabricator: Use an exponential backoff sleep time

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,5 @@
 [settings]
-known_first_party = libmozevent
+known_first_party = conftest,libmozevent
 known_third_party = aioamqp,aiohttp,aioredis,hglib,libmozdata,logbook,pytest,responses,setuptools,structlog,taskcluster
+force_single_line = True
+line_length = 159

--- a/libmozevent/bus.py
+++ b/libmozevent/bus.py
@@ -6,7 +6,8 @@ import multiprocessing
 import os
 import pickle
 from queue import Empty
-from typing import Any, Callable
+from typing import Any
+from typing import Callable
 
 import structlog
 

--- a/libmozevent/mercurial.py
+++ b/libmozevent/mercurial.py
@@ -16,7 +16,8 @@ import structlog
 from libmozdata.phabricator import PhabricatorPatch
 
 from libmozevent.phabricator import PhabricatorBuild
-from libmozevent.utils import batch_checkout, robust_checkout
+from libmozevent.utils import batch_checkout
+from libmozevent.utils import robust_checkout
 
 logger = structlog.get_logger(__name__)
 

--- a/libmozevent/monitoring.py
+++ b/libmozevent/monitoring.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 import asyncio
-from datetime import datetime, timedelta
-from typing import Dict, List
+from datetime import datetime
+from datetime import timedelta
+from typing import Dict
+from typing import List
 
 import structlog
 from taskcluster.helper import TaskclusterConfig
-from taskcluster.utils import slugId, stringDate
+from taskcluster.utils import slugId
+from taskcluster.utils import stringDate
 
 logger = structlog.get_logger(__name__)
 

--- a/libmozevent/phabricator.py
+++ b/libmozevent/phabricator.py
@@ -54,7 +54,7 @@ class PhabricatorActions(object):
     Common Phabricator actions shared across clients
     """
 
-    def __init__(self, url, api_key, retries=4, sleep=10):
+    def __init__(self, url, api_key, retries=5, sleep=10):
         self.api = PhabricatorAPI(url=url, api_key=api_key)
 
         # Phabricator secure revision retries configuration
@@ -92,7 +92,7 @@ class PhabricatorActions(object):
             return
 
         # Check this build has been awaited between tries
-        exp_backoff = (2 ** (self.max_retries - retries_left + 1) - 1) * self.sleep
+        exp_backoff = (2 ** (self.max_retries - retries_left)) * self.sleep
         now = time.time()
         if last_try is not None and now - last_try < exp_backoff:
             return

--- a/libmozevent/phabricator.py
+++ b/libmozevent/phabricator.py
@@ -54,12 +54,13 @@ class PhabricatorActions(object):
     Common Phabricator actions shared across clients
     """
 
-    def __init__(self, url, api_key, retries=5, sleep=10):
+    def __init__(self, url, api_key, retries=4, sleep=10):
         self.api = PhabricatorAPI(url=url, api_key=api_key)
 
         # Phabricator secure revision retries configuration
         assert isinstance(retries, int)
         assert isinstance(sleep, int)
+        self.max_retries = retries
         self.retries = collections.defaultdict(lambda: (retries, None))
         self.sleep = sleep
         logger.info(
@@ -91,7 +92,7 @@ class PhabricatorActions(object):
             return
 
         # Check this build has been awaited between tries
-        exp_backoff = (2 ** (self.retries - retries_left + 1) - 1) * self.sleep
+        exp_backoff = (2 ** (self.max_retries - retries_left + 1) - 1) * self.sleep
         now = time.time()
         if last_try is not None and now - last_try < exp_backoff:
             return

--- a/libmozevent/pulse.py
+++ b/libmozevent/pulse.py
@@ -7,7 +7,9 @@ import asyncio
 import fnmatch
 import itertools
 import json
-from typing import Dict, List, Tuple
+from typing import Dict
+from typing import List
+from typing import Tuple
 
 import aioamqp
 import structlog

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,8 @@ import json
 import os.path
 import urllib.parse
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 from unittest.mock import MagicMock
 
 import hglib
@@ -20,6 +21,8 @@ from taskcluster.utils import stringDate
 
 from libmozevent.mercurial import Repository
 from libmozevent.phabricator import PhabricatorActions
+from libmozevent.phabricator import PhabricatorBuild
+from libmozevent.phabricator import PhabricatorBuildState
 
 MOCK_DIR = os.path.join(os.path.dirname(__file__), "mocks")
 
@@ -338,3 +341,15 @@ def mock_taskcluster():
     tc.default_url = "http://taskcluster.test"
     tc.options["maxRetries"] = 1
     return tc
+
+
+class MockBuild(PhabricatorBuild):
+    def __init__(self, diff_id, repo_phid, revision_id, target_phid, diff):
+        self.diff_id = diff_id
+        self.repo_phid = repo_phid
+        self.revision_id = revision_id
+        self.target_phid = target_phid
+        self.diff = diff
+        self.stack = []
+        self.state = PhabricatorBuildState.Public
+        self.revision_url = None

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -205,11 +205,7 @@ async def test_run_async_parallel():
 
     assert bus.queues["input"].qsize() == 3
 
-    done = {
-        0: False,
-        1: False,
-        2: False,
-    }
+    done = {0: False, 1: False, 2: False}
 
     async def torun(count):
         await asyncio.sleep(0)
@@ -233,11 +229,7 @@ async def test_run_async_parallel():
     task.cancel()
     assert bus.queues["input"].qsize() == 0
     assert bus.queues["end"].qsize() == 0
-    assert done == {
-        0: False,
-        1: True,
-        2: True,
-    }
+    assert done == {0: False, 1: True, 2: True}
 
 
 @pytest.mark.asyncio

--- a/tests/test_mercurial.py
+++ b/tests/test_mercurial.py
@@ -5,27 +5,15 @@ import os.path
 
 import pytest
 
+from conftest import MockBuild
 from libmozevent.bus import MessageBus
 from libmozevent.mercurial import MercurialWorker
-from libmozevent.phabricator import PhabricatorBuild, PhabricatorBuildState
 
 MERCURIAL_FAILURE = """unable to find 'crash.txt' for patching
 (use '--prefix' to apply patch relative to the current directory)
 1 out of 1 hunks FAILED -- saving rejects to file crash.txt.rej
 abort: patch failed to apply
 """
-
-
-class MockBuild(PhabricatorBuild):
-    def __init__(self, diff_id, repo_phid, revision_id, target_phid, diff):
-        self.diff_id = diff_id
-        self.repo_phid = repo_phid
-        self.revision_id = revision_id
-        self.target_phid = target_phid
-        self.diff = diff
-        self.stack = []
-        self.state = PhabricatorBuildState.Public
-        self.revision_url = None
 
 
 @pytest.mark.asyncio

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -39,7 +39,7 @@ def test_backoff(PhabricatorMock):
         assert phab.is_visible.call_count == 2
 
         # Last iteration is even further away
-        time.sleep(0.4)
+        time.sleep(0.1)
         phab.update_state(build)
         assert build.state == PhabricatorBuildState.Queued
         assert phab.is_visible.call_count == 2

--- a/tests/test_phabricator.py
+++ b/tests/test_phabricator.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+import time
+from unittest.mock import Mock
+
+from conftest import MockBuild
+from libmozevent.phabricator import PhabricatorBuildState
+
+
+def test_backoff(PhabricatorMock):
+    """
+    Test update_state behaviour on retries
+    """
+    build = MockBuild(1234, "PHID-REPO-mc", 5678, "PHID-HMBT-deadbeef", {})
+    build.state = PhabricatorBuildState.Queued
+
+    with PhabricatorMock as phab:
+
+        # Lower the max time to sleep to keep a speedy test
+        phab.sleep = 0.1
+
+        # The revision will be visible at the 3 try
+        phab.is_visible = Mock(side_effect=[False, False, True])
+
+        # Will stay queued as private
+        phab.update_state(build)
+        assert build.state == PhabricatorBuildState.Queued
+        assert phab.is_visible.call_count == 1
+
+        # After a short sleep, no update is triggered
+        time.sleep(0.1)
+        phab.update_state(build)
+        assert build.state == PhabricatorBuildState.Queued
+        assert phab.is_visible.call_count == 1
+
+        # We need to still wait to get the next iteration
+        time.sleep(0.3)
+        phab.update_state(build)
+        assert build.state == PhabricatorBuildState.Queued
+        assert phab.is_visible.call_count == 2
+
+        # Last iteration is even further away
+        time.sleep(0.4)
+        phab.update_state(build)
+        assert build.state == PhabricatorBuildState.Queued
+        assert phab.is_visible.call_count == 2
+
+        # Finally it's public
+        time.sleep(0.4)
+        phab.update_state(build)
+        assert build.state == PhabricatorBuildState.Public
+        assert phab.is_visible.call_count == 3


### PR DESCRIPTION
Using tenacity would require a large refactoring, as the method is not retried in a direct loop, but through the usage of the libmozvent queues.

Fixes https://github.com/mozilla/code-review/issues/328