### PR TITLE
Use HIGHEST Pickle protocol for storage and bus

### DIFF
--- a/libmozevent/bus.py
+++ b/libmozevent/bus.py
@@ -54,7 +54,9 @@ class MessageBus(object):
 
         if isinstance(queue, RedisQueue):
             async with AsyncRedis() as redis:
-                await redis.rpush(queue.name, pickle.dumps(payload,protocol=pickle.HIGHEST_PROTOCOL))
+                await redis.rpush(
+                    queue.name, pickle.dumps(payload, protocol=pickle.HIGHEST_PROTOCOL)
+                )
 
         elif isinstance(queue, asyncio.Queue):
             await queue.put(payload)

--- a/libmozevent/bus.py
+++ b/libmozevent/bus.py
@@ -54,7 +54,7 @@ class MessageBus(object):
 
         if isinstance(queue, RedisQueue):
             async with AsyncRedis() as redis:
-                await redis.rpush(queue.name, pickle.dumps(payload))
+                await redis.rpush(queue.name, pickle.dumps(payload,protocol=pickle.HIGHEST_PROTOCOL))
 
         elif isinstance(queue, asyncio.Queue):
             await queue.put(payload)

--- a/libmozevent/storage.py
+++ b/libmozevent/storage.py
@@ -36,7 +36,7 @@ class EphemeralStorage:
             async with AsyncRedis() as redis:
                 await redis.expire(self.name, self.expiration)
                 await redis.set(
-                    self._redis_key(key), pickle.dumps(value), expire=self.expiration
+                    self._redis_key(key), pickle.dumps(value,protocol=pickle.HIGHEST_PROTOCOL), expire=self.expiration
                 )
 
     async def rem(self, key):

--- a/libmozevent/storage.py
+++ b/libmozevent/storage.py
@@ -36,7 +36,9 @@ class EphemeralStorage:
             async with AsyncRedis() as redis:
                 await redis.expire(self.name, self.expiration)
                 await redis.set(
-                    self._redis_key(key), pickle.dumps(value,protocol=pickle.HIGHEST_PROTOCOL), expire=self.expiration
+                    self._redis_key(key),
+                    pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL),
+                    expire=self.expiration,
                 )
 
     async def rem(self, key):


### PR DESCRIPTION
Changing from default protocol to highest protocol while dumping data using pickle.
Issue ref: https://github.com/mozilla/libmozevent/issues/51