### PR TITLE
Using librabbitmq instead of aioamqp

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
 known_first_party = conftest,libmozevent
-known_third_party = aioamqp,aiohttp,aioredis,hglib,libmozdata,logbook,pytest,responses,setuptools,structlog,taskcluster
+known_third_party = aioamqp,aiohttp,aioredis,hglib,libmozdata,librabbitmq,logbook,pytest,responses,setuptools,structlog,taskcluster
 force_single_line = True
 line_length = 159

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aioamqp>=0.13.0
 aiohttp
 aioredis
 libmozdata
+librabbitmq
 Logbook
 python-hglib
 pytoml


### PR DESCRIPTION
PR for issue #21 

Notes:
- No replacement for `basic_qos` in librabbitmq
- No state `AmqpClosedConnection` in librabbitmq, so how should errors (line 136 in pulse.py) be handled?