### PR TITLE
utils: AsyncRedis refactoring and aioredis upgrade to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aioamqp>=0.13.0
 aiohttp
-aioredis
+aioredis>=2.0.0
 libmozdata
 Logbook
 python-hglib


### PR DESCRIPTION
- Upgrade to aioredis 2.0.0
- as talked with @marco-c it's a good idea to cache the connection and to use a connection pool with auto-reconnect. The connection is cached as a static member field 