### PR TITLE
WIP: Allow to stop a bus worker

### DIFF
--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -112,7 +112,7 @@ async def test_run_async_without_output_queue():
 
     task = asyncio.create_task(bus.run(torun, "input"))
 
-    await bus.receive("end") == 1
+    assert await bus.receive("end") == 1
     task.cancel()
     assert bus.queues["input"].qsize() == 0
     assert bus.queues["end"].qsize() == 0


### PR DESCRIPTION
Related to mozilla/code-review#1267

Allow to stop nicely any worker reacting to a queue message. Actually, every worker has a specific behavior inside the `run` method.

This work is still in progress :
* [x] Use a generic mixin for workers
* [x] Update mercurial worker
* [x] Update monitoring worker
* [x] Update pulse worker
* [x] Update bus direct handler (e.g. phabricator worker)
* [x] Fix existing tests
* [ ] Check everything works correctly (in code review bot events)
* [ ] Update tests