### PR TITLE
Add a missing_base_revision boolean to PhabricatorBuild

### DIFF
--- a/libmozevent/mercurial.py
+++ b/libmozevent/mercurial.py
@@ -141,7 +141,8 @@ class Repository(object):
 
         # When base revision is missing, update to default revision
         hg_base = needed_stack[0].base_revision
-        if not self.has_revision(hg_base):
+        build.missing_base_revision = not self.has_revision(hg_base)
+        if build.missing_base_revision:
             logger.info(
                 "Missing base revision from Phabricator",
                 revision=hg_base,

--- a/libmozevent/phabricator.py
+++ b/libmozevent/phabricator.py
@@ -46,6 +46,7 @@ class PhabricatorBuild(object):
         self.reviewers = []
         self.diff = None
         self.stack = []
+        self.missing_base_revision = False
 
     def __str__(self):
         return "Revision {} - {}".format(self.revision_id, self.target_phid)


### PR DESCRIPTION
References https://github.com/mozilla/code-review/issues/102

This new attribute is needed to determine whether to alert (via Phabricator) that the base revision changed for a patch analyzed by the `code-review-bot` or not.

@abpostelnicu We will need a new release of `libmozevent` to finish this work on `code-review-bot`.