### PR TITLE
Allow to restore bus messages for sequential tasks

### DIFF
--- a/libmozevent/bus.py
+++ b/libmozevent/bus.py
@@ -119,10 +119,11 @@ class MessageBus(object):
 
     async def restore_redis_messages(self):
         """
-        Restores currently processed Redis messages
-        Only sequential jobs can be restored this way, parallel jobs will be ignored
-        This method should be called in case a fail occurred processing messages on one or more queue,
-        in order to restore non fully processed messages in Redis
+        Restores a currently processed message for each Redis queue on this bus.
+        Parallel jobs on a same queue will be ignored, as the last processed
+        message is erased when awaiting a new message on the queue.
+        This method can be called when a failure occurs while running jobs on a
+        bus queue, in order to restore non fully processed messages in Redis.
         """
         logger.info("Restoring non processed messages")
         redis = await AsyncRedis.connect()

--- a/libmozevent/bus.py
+++ b/libmozevent/bus.py
@@ -119,14 +119,16 @@ class MessageBus(object):
 
     async def restore_redis_messages(self):
         """
-        Restore currently processed Redis messages
-        This method should be called in case a fail occurred processing
-        messages on one or more queue, in order to retry
+        Restores currently processed Redis messages
+        Only sequential jobs can be restored this way, parallel jobs will be ignored
+        This method should be called in case a fail occurred processing messages on one or more queue,
+        in order to restore non fully processed messages in Redis
         """
+        logger.info("Restoring non processed messages")
         redis = await AsyncRedis.connect()
         assert redis is not None
         for queue_name, payload in self.redis_messages.items():
-            # Insert as TOP message
+            # Insert message in the top of the Redis queue
             await redis.lpush(queue_name, payload)
 
     async def run(

--- a/libmozevent/bus.py
+++ b/libmozevent/bus.py
@@ -27,6 +27,8 @@ class MessageBus(object):
         self.queues = {}
         self.redis_enabled = "REDIS_URL" in os.environ
         logger.info("Redis support", enabled=self.redis_enabled and "yes" or "no")
+        # Stores currently consumed Redis messages
+        self.redis_messages = {}
 
     def add_queue(
         self, name: str, mp: bool = False, redis: bool = False, maxsize: int = -1
@@ -79,10 +81,20 @@ class MessageBus(object):
         logger.debug("Wait for message on bus", queue=name, instance=queue)
 
         if isinstance(queue, RedisQueue):
+
+            # Clean the last processed message as we are awaiting a new one on this queue
+            if name in self.redis_messages:
+                del self.redis_messages[name]
+
             redis = await AsyncRedis.connect()
             assert redis is not None
             _, payload = await redis.blpop(queue.name)
             assert isinstance(payload, bytes)
+
+            # Save the currently processed message
+            # This ensures that we can restore the message in case of a failure
+            self.redis_messages[name] = payload
+
             try:
                 return pickle.loads(payload)
             except Exception as e:
@@ -104,6 +116,18 @@ class MessageBus(object):
                         await asyncio.sleep(1)
 
             return await _get()
+
+    async def restore_redis_messages(self):
+        """
+        Restore currently processed Redis messages
+        This method should be called in case a fail occurred processing
+        messages on one or more queue, in order to retry
+        """
+        redis = await AsyncRedis.connect()
+        assert redis is not None
+        for queue_name, payload in self.redis_messages.items():
+            # Insert as TOP message
+            await redis.lpush(queue_name, payload)
 
     async def run(
         self,

--- a/libmozevent/bus.py
+++ b/libmozevent/bus.py
@@ -128,8 +128,9 @@ class MessageBus(object):
         redis = await AsyncRedis.connect()
         assert redis is not None
         for queue_name, payload in self.redis_messages.items():
+            queue = self.queues[queue_name]
             # Insert message in the top of the Redis queue
-            await redis.lpush(queue_name, payload)
+            await redis.lpush(queue.name, payload)
 
     async def run(
         self,

--- a/libmozevent/utils.py
+++ b/libmozevent/utils.py
@@ -51,6 +51,7 @@ def run_tasks(awaitables: Iterable, bus=None):
             # When ANY exception from one of the awaitables
             # make sure the other awaitables are cancelled
             tasks_group.cancel()
+            raise asyncio.CancelledError
 
     try:
         event_loop.run_until_complete(_run())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,20 @@
 # -*- coding: utf-8 -*-
 import asyncio
+import os
+import pickle
+import signal
+from unittest.mock import Mock
+
+import pytest
 
 from libmozevent import utils
+from libmozevent.bus import AsyncRedis
+from libmozevent.bus import MessageBus
+from libmozevent.bus import RedisQueue
+
+
+def unexpected_error():
+    raise Exception("Unexpected")
 
 
 def test_run_tasks():
@@ -20,3 +33,65 @@ def test_run_tasks():
 
     utils.run_tasks(set([do(), do(), do()]))
     assert count == 9
+
+
+@pytest.mark.parametrize(
+    "task_side_effect",
+    [
+        lambda: os.kill(os.getpid(), signal.SIGTERM),
+        unexpected_error,
+    ],
+)
+def test_run_tasks_restore_redis_messages(task_side_effect):
+    """
+    When using a Redis queue, messages are restored in case of an unexpected failure or
+    if a SIGTERM is received
+    """
+    redis_mock = Mock(spec=RedisQueue)
+
+    async def redis_connect():
+        return redis_mock
+
+    AsyncRedis.connect = Mock(side_effect=redis_connect)
+
+    redis_queue = []
+
+    async def await_rpush(*args):
+        redis_queue.append(args)
+
+    async def await_lpush(*args):
+        redis_queue.insert(0, args)
+
+    async def await_blpop(*args):
+        return redis_queue.pop(0)
+
+    redis_mock.rpush = await_rpush
+    redis_mock.lpush = await_lpush
+    redis_mock.blpop = await_blpop
+
+    os.environ.update(REDIS_URL="redis://localhost")
+    bus = MessageBus()
+
+    bus.add_queue("input", redis=True)
+    assert len(bus.queues) == 1
+    assert redis_queue == []
+
+    asyncio.get_event_loop().run_until_complete(bus.send("input", "message"))
+    queue_name = bus.queues["input"].name
+    message = pickle.dumps("message", protocol=pickle.HIGHEST_PROTOCOL)
+
+    assert redis_queue == [(queue_name, message)]
+
+    async def deadly_task():
+        await bus.receive("input")
+        # Ensure the message has been consumed
+        assert redis_queue == []
+        # Raise an unexpected error or send a TERM signal to itself
+        task_side_effect()
+        await asyncio.sleep(10)
+
+    with pytest.raises(asyncio.CancelledError):
+        utils.run_tasks([deadly_task()], bus=bus)
+
+    # Message has been send back in the queue
+    assert redis_queue == [(queue_name, message)]


### PR DESCRIPTION
Related to https://github.com/mozilla/code-review/issues/1267

Simpler approach than [using a WorkerMixin](!77)

* [x] Write/Update tests