### PR TITLE
Improve logging in Repository.apply_build()

### DIFF
--- a/libmozevent/phabricator.py
+++ b/libmozevent/phabricator.py
@@ -46,6 +46,7 @@ class PhabricatorBuild(object):
         self.reviewers = []
         self.diff = None
         self.stack = []
+        self.initial_base_revision = None
         self.missing_base_revision = False
 
     def __str__(self):


### PR DESCRIPTION
This PR introduces various changes:   

Closes #82   
- Changing log level for the "Missing base revision" message from `INFO` to `WARNING`
- Adding a new `ERROR` log when the patch fails to apply

References https://github.com/mozilla/code-review/issues/1352
- Adding a new attribute to `PhabricatorBuild` called `initial_base_revision` to improve the logging on Code Review Bot side (preliminary work)