### PR TITLE
Limit base docker image to python 3.10

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -49,7 +49,7 @@ tasks:
       deadline: {$fromNow: '1 hour'}
       payload:
         maxRunTime: 3600
-        image: python:3
+        image: python:3.10
         command:
           - sh
           - -lxce
@@ -69,7 +69,7 @@ tasks:
       deadline: {$fromNow: '1 hour'}
       payload:
         maxRunTime: 3600
-        image: python:3
+        image: python:3.10
         command:
           - sh
           - -lxce


### PR DESCRIPTION
Starting with newer base docker images, 3.11+ aioredis is not compatible. More than this `rs_parsepatch` needs to be built so we would need to ship in the docker image rust/cargo.