### PR TITLE
Use a more generic way to retry http/s failures for different implementations. Fixes #95

### DIFF
--- a/libmozevent/phabricator.py
+++ b/libmozevent/phabricator.py
@@ -5,6 +5,7 @@ import time
 
 import structlog
 from libmozdata.phabricator import PhabricatorAPI
+
 from libmozevent.utils import get_session
 
 logger = structlog.get_logger(__name__)

--- a/libmozevent/phabricator.py
+++ b/libmozevent/phabricator.py
@@ -5,6 +5,7 @@ import time
 
 import structlog
 from libmozdata.phabricator import PhabricatorAPI
+from libmozevent.utils import get_session
 
 logger = structlog.get_logger(__name__)
 
@@ -21,10 +22,10 @@ class PhabricatorBuild(object):
     """
 
     def __init__(self, request):
-        self.diff_id = int(request.rel_url.query.get("diff", 0))
-        self.repo_phid = request.rel_url.query.get("repo")
-        self.revision_id = int(request.rel_url.query.get("revision", 0))
-        self.target_phid = request.rel_url.query.get("target")
+        self.diff_id = int(get_session("phabricator", request).rel_url.query.get("diff", 0))
+        self.repo_phid = get_session("phabricator", request).rel_url.query.get("repo")
+        self.revision_id = int(get_session("phabricator", request).rel_url.query.get("revision", 0))
+        self.target_phid = get_session("phabricator", request).rel_url.query.get("target")
         self.state = PhabricatorBuildState.Queued
         # Incremented on an unexpected failure during build's push to try
         self.retries = 0

--- a/libmozevent/phabricator.py
+++ b/libmozevent/phabricator.py
@@ -22,10 +22,16 @@ class PhabricatorBuild(object):
     """
 
     def __init__(self, request):
-        self.diff_id = int(get_session("phabricator", request).rel_url.query.get("diff", 0))
+        self.diff_id = int(
+            get_session("phabricator", request).rel_url.query.get("diff", 0)
+        )
         self.repo_phid = get_session("phabricator", request).rel_url.query.get("repo")
-        self.revision_id = int(get_session("phabricator", request).rel_url.query.get("revision", 0))
-        self.target_phid = get_session("phabricator", request).rel_url.query.get("target")
+        self.revision_id = int(
+            get_session("phabricator", request).rel_url.query.get("revision", 0)
+        )
+        self.target_phid = get_session("phabricator", request).rel_url.query.get(
+            "target"
+        )
         self.state = PhabricatorBuildState.Queued
         # Incremented on an unexpected failure during build's push to try
         self.retries = 0

--- a/libmozevent/utils.py
+++ b/libmozevent/utils.py
@@ -5,10 +5,10 @@
 import asyncio
 import contextvars
 import fcntl
-from functools import lru_cache
 import os
 import signal
 import time
+from functools import lru_cache
 from typing import Iterable
 
 import hglib

--- a/libmozevent/utils.py
+++ b/libmozevent/utils.py
@@ -23,6 +23,7 @@ from redis.exceptions import RedisError
 from redis.exceptions import ResponseError
 from redis.exceptions import TimeoutError
 from redis.exceptions import WatchError
+from requests.packages.urllib3.util.retry import Retry
 
 log = structlog.get_logger(__name__)
 


### PR DESCRIPTION
This is based on on [implementation](https://github.com/mozilla/bugbug/blob/9c21295d2d32ce6a1b6b50bc48b6b8285226fb5b/bugbug/utils.py#L424-L439) from mozilla/bugbug.