### PR TITLE
Bump mypy in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     hooks:
       - id: yesqa
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev:  v1.12.1
     hooks:
       - id: mypy
         additional_dependencies:


### PR DESCRIPTION
To fix this error

```
/root/.cache/pre-commit/repos708qki0/py_env-python3/lib/python3.10/site-packages/redis-stubs/cluster.pyi:253: error:(B Positional-only parameters are only supported in Python 3.8 and greater(B
Found 1 error in 1 file (errors prevented further checking)(B
```
in pre-commit