### PR TITLE
phabricator: Retry up to 6 times, with 15 s wait

### DIFF
--- a/libmozevent/phabricator.py
+++ b/libmozevent/phabricator.py
@@ -59,7 +59,7 @@ class PhabricatorActions(object):
     Common Phabricator actions shared across clients
     """
 
-    def __init__(self, url, api_key, retries=5, sleep=10):
+    def __init__(self, url, api_key, retries=6, sleep=15):
         self.api = PhabricatorAPI(url=url, api_key=api_key)
 
         # Phabricator secure revision retries configuration


### PR DESCRIPTION
Fixes #93

We were previously waiting:
2^0 * 10 = 10s
2^1 * 10 = 20s
2^2 * 10 = 40s
2^3 * 10 = 80s
2^4 * 10 = 160s
for a total of 310 seconds (slightly more than 5 minutes)

We are now going to wait:
2^0 * 15 = 15s
2^1 * 15 = 30s
2^2 * 15 = 60s
2^3 * 15 = 120s
2^4 * 15 = 240s
2^5 * 15 = 480s
for a total of 945 seconds (almost 16 minutes)